### PR TITLE
Slurp errors to keep errcheck happy

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -394,7 +394,7 @@ func ExecMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirecti
 		for _, stmt := range migration.Queries {
 			if _, err := executor.Exec(stmt); err != nil {
 				if trans, ok := executor.(*gorp.Transaction); ok {
-					trans.Rollback()
+					_ = trans.Rollback()
 				}
 
 				return applied, newTxError(migration, err)
@@ -409,7 +409,7 @@ func ExecMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirecti
 			})
 			if err != nil {
 				if trans, ok := executor.(*gorp.Transaction); ok {
-					trans.Rollback()
+					_ = trans.Rollback()
 				}
 
 				return applied, newTxError(migration, err)
@@ -420,7 +420,7 @@ func ExecMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirecti
 			})
 			if err != nil {
 				if trans, ok := executor.(*gorp.Transaction); ok {
-					trans.Rollback()
+					_ = trans.Rollback()
 				}
 
 				return applied, newTxError(migration, err)
@@ -551,7 +551,7 @@ func SkipMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirecti
 		})
 		if err != nil {
 			if trans, ok := executor.(*gorp.Transaction); ok {
-				trans.Rollback()
+				_ = trans.Rollback()
 			}
 
 			return applied, newTxError(migration, err)

--- a/sql-migrate/command_new.go
+++ b/sql-migrate/command_new.go
@@ -83,7 +83,7 @@ func CreateMigration(name string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if err := tpl.Execute(f, nil); err != nil {
 		return err

--- a/sql-migrate/main.go
+++ b/sql-migrate/main.go
@@ -44,7 +44,7 @@ func realMain() int {
 
 	exitCode, err := cli.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error executing CLI: %s\n", err.Error())
+		_, _ = fmt.Fprintf(os.Stderr, "Error executing CLI: %s\n", err.Error())
 		return 1
 	}
 


### PR DESCRIPTION
Not sure if upstream is using errcheck, so likely will not publish this change to them, unless they are welcome to it. Publishing as its own PR to keep that bookkeeping separate.

Already accidentally pushed this to their repo though: https://github.com/rubenv/sql-migrate/pull/124

There is nothing really to do with these errors.

* There are no loggers in the top-level library code, and this is
  already in the rollback error control flow, so there is no erroring to
  signal (we already are).
* The failure to print to stderr in the main sql-migrate doesn't seem
  to have any sane recourse.
* We could consider a message in the failure to close the file
  descriptor, but this logic is going to be moved up to the library,
  which still doesn't have a logger, and this is already when we are
  going through the error path, so there is no error to return.